### PR TITLE
Make Subs support immediate replacement

### DIFF
--- a/symengine/functions.cpp
+++ b/symengine/functions.cpp
@@ -1788,6 +1788,9 @@ RCP<const Basic> Subs::diff(const RCP<const Symbol> &x) const
 
 RCP<const Basic> Subs::subs(const map_basic_basic &subs_dict) const
 {
+    auto it = subs_dict.find(rcp_from_this());
+    if (it != subs_dict.end())
+        return it->second;
     map_basic_basic m, n;
     for (auto &p: subs_dict) {
         bool found = false;

--- a/symengine/tests/basic/test_functions.cpp
+++ b/symengine/tests/basic/test_functions.cpp
@@ -830,6 +830,9 @@ TEST_CASE("Subs: functions", "[functions]")
     r3 = Subs::create(Derivative::create(function_symbol("f", {y, x}), {x}), {{x, add(z, y)}});
     REQUIRE(eq(*r2, *r3));
 
+    r2 = r1->subs({{r1, r3}});
+    REQUIRE(eq(*r2, *r3));
+
     // Test Subs::diff
     r1 = function_symbol("f", {add(y, y), add(x, y)})->diff(x);
 


### PR DESCRIPTION
A pull revamping subs should probably have this. It allows the results
of some chain rule calculations to be manipulated more easily if
commonly needed derivatives are stored beforehand.